### PR TITLE
Fix GitHub repo url for `r-html/rhtml`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:rhtml/rhtml.git"
+    "url": "git@github.com:r-html/rhtml.git"
   },
   "author": "Kristiyan Tachev",
   "license": "MIT",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:rhtml/rhtml.git"
+    "url": "git@github.com:r-html/rhtml.git"
   },
   "dependencies": {
     "@rxdi/lit-html": "^0.7.225",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {},
   "repository": {
     "type": "git",
-    "url": "git@github.com:rhtml/rhtml.git"
+    "url": "git@github.com:r-html/rhtml.git"
   },
   "author": "Kristiyan Tachev",
   "license": "MIT",

--- a/packages/custom-attributes/package.json
+++ b/packages/custom-attributes/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:rhtml/rhtml.git"
+    "url": "git@github.com:r-html/rhtml.git"
   },
   "dependencies": {},
   "devDependencies": {},

--- a/packages/decorators/package.json
+++ b/packages/decorators/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:rhtml/rhtml.git"
+    "url": "git@github.com:r-html/rhtml.git"
   },
   "dependencies": {},
   "devDependencies": {},

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {},
   "repository": {
     "type": "git",
-    "url": "git@github.com:rhtml/rhtml.git"
+    "url": "git@github.com:r-html/rhtml.git"
   },
   "author": "Kristiyan Tachev",
   "license": "MIT",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {},
   "repository": {
     "type": "git",
-    "url": "git@github.com:rhtml/rhtml.git"
+    "url": "git@github.com:r-html/rhtml.git"
   },
   "author": "Kristiyan Tachev",
   "license": "MIT",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:rhtml/rhtml.git"
+    "url": "git@github.com:r-html/rhtml.git"
   },
   "dependencies": {
     "@rxdi/lit-html": "^0.7.225"

--- a/packages/modifiers/package.json
+++ b/packages/modifiers/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:rhtml/rhtml.git"
+    "url": "git@github.com:r-html/rhtml.git"
   },
   "dependencies": {
     "@rhtml/custom-attributes": "0.0.148",

--- a/packages/operators/package.json
+++ b/packages/operators/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:rhtml/rhtml.git"
+    "url": "git@github.com:r-html/rhtml.git"
   },
   "author": "Kristiyan Tachev",
   "license": "MIT",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:rhtml/rhtml.git"
+    "url": "git@github.com:r-html/rhtml.git"
   },
   "dependencies": {
     "@rxdi/lit-html": "^0.7.225"

--- a/packages/schematics/package.json
+++ b/packages/schematics/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {},
   "repository": {
     "type": "git",
-    "url": "git@github.com:rhtml/rhtml.git"
+    "url": "git@github.com:r-html/rhtml.git"
   },
   "author": "Kristiyan Tachev",
   "license": "MIT",

--- a/packages/virtualizer/package.json
+++ b/packages/virtualizer/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:rhtml/rhtml.git"
+    "url": "git@github.com:r-html/rhtml.git"
   },
   "dependencies": {
     "@rxdi/lit-html": "^0.7.225"


### PR DESCRIPTION
# Description

I just noticed that the GitHub URL for this repo wasn't right after I tried to click on the repo URL on NPM so this pull request fixes it in all `package.json` files.

## Type of change

- [x] Non Breaking change
- [ ] Breaking change

## Notes (specific implementation details)

\-

## Screenshots (optional)

<img width="2406" height="1046" alt="CleanShot 2026-05-02 at 16 30 47@2x" src="https://github.com/user-attachments/assets/6e91cea0-f85d-440b-896b-f9a911318e8f" />
